### PR TITLE
Optimizations and small fixes

### DIFF
--- a/src/MerchantFrontend/src/assets/i18n/de.json
+++ b/src/MerchantFrontend/src/assets/i18n/de.json
@@ -96,7 +96,7 @@
 	"MERCHANT.DETAILS.HEADLINE": "Deine Informationen",
 	"MERCHANT.DETAILS.HOMEPAGE": "Internetseite (Optional)",
 	"MERCHANT.DETAILS.HOMEPAGE_PLACEHOLDER": "Du kannst hier den Link Deiner Internetseite angeben",
-	"MERCHANT.DETAILS.LEGAL_INFORMATION": "Rechtilche Informationen",
+	"MERCHANT.DETAILS.LEGAL_INFORMATION": "Rechtliche Informationen",
 	"MERCHANT.DETAILS.LEGAL_INFORMATION_TEXT": "<br/>Starten Sie Ihr Online Business mit dem Händlerbund rechtssicher<br/><br/> In Rechtstexten wie AGB, Widerrufsbelehrung und Impressum können zahlreiche Fehler gemacht werden, die nicht nur Ärger mit Kunden, sondern auch teure Abmahnungen zur Folge haben können. Unser Partner Der Händlerbund stellt Ihnen zum Start Ihrer Online Aktivitäten alle benötigten Rechtstexte zur Verfügung und ermöglichte eine einfache Einbindung der Texte in Ihren Downtown Shop. Im Rahmen des Händlerpunktpakets sind für 3 Monate ohne zusätzliche Kosten Rechtstexte enthalten.<br/><br/>Hier weitere Infos und der Zugang zum Händlerbund<br/> <a href='https://marketplace.haendlerbund.de/haendlerbund-basic-mitgliedschaftspaket-downtown'>https://marketplace.haendlerbund.de/haendlerbund-basic-mitgliedschaftspaket-downtown</a><br/><br/>Im Warenkorb vom Händlerbund geben Sie bitte den Rabattcode Basic3gratis. Start und Ende der dreimonatigen kostenlosen Mitgliedschaft laufen dann im Hintergrund automatisch an.",
 	"MERCHANT.DETAILS.LOADING": "Lädt...",
 	"MERCHANT.DETAILS.LOCATION_PLACEHOLDER": "Stadt diner Firma",

--- a/src/Merchants/Content/Merchant/MerchantDefinition.php
+++ b/src/Merchants/Content/Merchant/MerchantDefinition.php
@@ -92,10 +92,10 @@ class MerchantDefinition extends EntityDefinition
             (new PasswordField('password', 'password'))->addFlags(new Required(), new ReadProtected(SalesChannelApiSource::class)),
             (new StringField('phone_number', 'phoneNumber')),
 
-            (new StringField('imprint', 'imprint')),
-            (new StringField('tos', 'tos')),
-            (new StringField('privacy', 'privacy')),
-            (new StringField('revocation', 'revocation')),
+            (new LongTextField('imprint', 'imprint')),
+            (new LongTextField('tos', 'tos')),
+            (new LongTextField('privacy', 'privacy')),
+            (new LongTextField('revocation', 'revocation')),
 
 
             (new StringField('mollie_prod_key', 'mollieProdKey')),

--- a/src/Merchants/DependencyInjection/storefront.xml
+++ b/src/Merchants/DependencyInjection/storefront.xml
@@ -47,5 +47,9 @@
             <argument type="service" id="Shopware\Production\Merchants\Storefront\Cms\SalesChannelCmsPageLoader.inner"/>
             <argument type="service" id="Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver"/>
         </service>
+
+        <service id="Shopware\Production\Merchants\Storefront\Page\Product\Subscriber\ProductPageCriteriaSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Merchants/Storefront/Page/Product/Subscriber/ProductPageCriteriaSubscriber.php
+++ b/src/Merchants/Storefront/Page/Product/Subscriber/ProductPageCriteriaSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Production\Merchants\Storefront\Page\Product\Subscriber;
+
+use Shopware\Production\Merchants\Content\Merchant\MerchantAvailableFilter;
+use Shopware\Storefront\Page\Product\ProductLoaderCriteriaEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ProductPageCriteriaSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            ProductLoaderCriteriaEvent::class => 'onProductCriteriaLoaded'
+        ];
+    }
+
+    public function onProductCriteriaLoaded(ProductLoaderCriteriaEvent $event): void
+    {
+        $event->getCriteria()
+            ->addAssociation('merchants')
+            ->addFilter(new MerchantAvailableFilter(
+                $event->getSalesChannelContext()->getSalesChannel()->getId(), 'merchants'
+            ));
+    }
+}

--- a/src/Organization/DependencyInjection/storefront.xml
+++ b/src/Organization/DependencyInjection/storefront.xml
@@ -8,6 +8,7 @@
         <service id="Shopware\Production\Organization\Storefront\Controller\StaticPageController" public="true">
             <argument type="service" id="organization.repository"/>
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
         </service>
     </services>
 </container>

--- a/src/Organization/Storefront/Controller/StaticPageController.php
+++ b/src/Organization/Storefront/Controller/StaticPageController.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\TextStruct;
+use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -40,12 +41,19 @@ class StaticPageController extends StorefrontController
      */
     private $genericPageLoader;
 
+    /**
+     * @var Translator
+     */
+    private $translator;
+
     public function __construct(
         EntityRepositoryInterface $organizationRepository,
-        GenericPageLoader $genericPageLoader
+        GenericPageLoader $genericPageLoader,
+        Translator $translator
     ) {
         $this->organizationRepository = $organizationRepository;
         $this->genericPageLoader = $genericPageLoader;
+        $this->translator = $translator;
     }
 
     /**
@@ -83,8 +91,12 @@ class StaticPageController extends StorefrontController
 
     private function addCmsPage(OrganizationEntity $organization, NavigationPage $page, string $field): void
     {
+        $headline = $this->translator->trans("page.{$field}");
+
         $textStructure = new TextStruct();
-        $textStructure->setContent($organization->jsonSerialize()[$field] ?? '');
+        $textStructure->setContent(
+            "<h2>{$headline}</h2>\n" . nl2br($organization->jsonSerialize()[$field] ?? '')
+        );
 
         $slot = new CmsSlotEntity();
         $slot->setId(Uuid::randomHex());

--- a/src/Portal/Resources/snippets/de_DE/translation.json
+++ b/src/Portal/Resources/snippets/de_DE/translation.json
@@ -12,7 +12,10 @@
         "imprint": "Impressum",
         "tos": "Allgemeine Geschäftsbedingungen",
         "privacy": "Datenschutz",
-        "revocation": "Wiederrufsrecht"
+        "revocation": "Wiederrufsrecht",
+        "modal": {
+            "closeModal": "Schließen"
+        }
     },
     "checkout": {
         "cartContainsMultipleMerchants": "Es können nur Produkte von einem Händler gleichzeitig gekauft werden",

--- a/src/Portal/Resources/snippets/en_GB/translation.json
+++ b/src/Portal/Resources/snippets/en_GB/translation.json
@@ -12,7 +12,10 @@
         "imprint": "Imprint",
         "tos": "Terms of Service",
         "privacy": "Privacy",
-        "revocation": "Revocation"
+        "revocation": "Revocation",
+        "modal": {
+            "closeModal": "Close"
+        }
     },
     "checkout": {
         "cartContainsMultipleMerchants": "Products can be purchased from only one merchant at a time",

--- a/src/Portal/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Portal/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -70,7 +70,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -90,7 +92,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -110,7 +114,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/Portal/Resources/views/storefront/page/merchant/detail.html.twig
+++ b/src/Portal/Resources/views/storefront/page/merchant/detail.html.twig
@@ -224,7 +224,7 @@
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="exampleModalLabel">{{ 'merchant.imprint'|trans }}</h5>
+                        <h5 class="modal-title">{{ 'merchant.imprint'|trans }}</h5>
                     </div>
                     <div class="modal-body">
                         <p>
@@ -232,7 +232,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -252,7 +254,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -272,7 +276,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>
@@ -292,7 +298,9 @@
                         </p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                            {{ 'merchant.modal.closeModal'|trans }}
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/Portal/Resources/views/storefront/page/product-detail/headline.html.twig
+++ b/src/Portal/Resources/views/storefront/page/product-detail/headline.html.twig
@@ -1,0 +1,16 @@
+{% sw_extends '@Storefront/storefront/page/product-detail/headline.html.twig' %}
+
+{% block page_product_detail_manufacturer %}
+    {% set merchant = page.product.extensions.merchants.first() %}
+    {% if merchant %}
+        <div class="col-md-auto product-detail-merchant">
+            <a href="{{ seoUrl('storefront.merchant.detail', {'id': merchant.id}) }}"
+               class="product-detail-merchant-link"
+               title="{{ merchant.publicCompanyName }}">
+                {{ merchant.publicCompanyName }}
+            </a>
+        </div>
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
- Fixed typo in german snippet file for merchant frontend
- Changed definition of fields imprint, tos, privacy and revocation to LongTextField to match database data type and make it possible to save longer values (255 characters are clearly too few for a complete imprint or data protection regulations)
- Added nl2br for organization static pages with imprint, tos and privacy, otherwise everything is output without line breaks
- Added headline with page name to static pages
- Added name of merchant on product detail page with link to the merchant detail page (at the same place where the manufacturer would be)
- Added merchant available filter for products: Products of non-public merchants are no longer accessible
- Added snippet for the merchant modal close button